### PR TITLE
Configurable MQTT client ID, CSA mode, and `no-output` option

### DIFF
--- a/EtherCatMQTTGateway.sln
+++ b/EtherCatMQTTGateway.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EtherCatMqttGateway", "EtherCatMqttGateway\EtherCatMqttGateway.csproj", "{9104FC5B-BC2D-B1C5-1F8D-AEEA58F60471}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9104FC5B-BC2D-B1C5-1F8D-AEEA58F60471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9104FC5B-BC2D-B1C5-1F8D-AEEA58F60471}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9104FC5B-BC2D-B1C5-1F8D-AEEA58F60471}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9104FC5B-BC2D-B1C5-1F8D-AEEA58F60471}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C46E0118-8B05-4DA2-BDA4-73660B38DAC0}
+	EndGlobalSection
+EndGlobal

--- a/EtherCatMqttGateway/Program.cs
+++ b/EtherCatMqttGateway/Program.cs
@@ -70,6 +70,14 @@ namespace EtherCatMqttGateway
         /// <summary>Debug logging.</summary>
         [Option("debug", Required = false, Default = false, HelpText = "Debug logging.")]
         public bool Debug { get; set; }
+
+        /// <summary>MQTT client ID (default: EtherCATMaster).</summary>
+        [Option("client-id", Required = false, Default = "EtherCATMaster", HelpText = "MQTT client ID.")]
+        public string ClientId { get; set; } = "EtherCATMaster";
+
+        /// <summary>Use reported CSA instead of ring CSA for MQTT topics (default: false).</summary>
+        [Option("use-reported-csa", Required = false, Default = false, HelpText = "Use reported CSA instead of ring CSA for MQTT topics.")]
+        public bool UseReportedCsa { get; set; }
     }
 
     /// <summary>
@@ -86,7 +94,9 @@ namespace EtherCatMqttGateway
             uint FrequencyHz,
             bool RetainProcessData,
             bool NoPublishOutputs,
-            LogLevel LogLevel);
+            LogLevel LogLevel,
+            string ClientId,
+            bool UseReportedCsa);
 
         private sealed record WriteRequest(ushort Csa, ushort Index, byte SubIndex, JToken Value);
 
@@ -178,7 +188,9 @@ namespace EtherCatMqttGateway
                 FrequencyHz: cli.FrequencyHz,
                 RetainProcessData: cli.RetainProcessData,
                 NoPublishOutputs: cli.NoOutput,
-                LogLevel: level
+                LogLevel: level,
+                ClientId: cli.ClientId,
+                UseReportedCsa: cli.UseReportedCsa
             );
         }
 
@@ -188,8 +200,8 @@ namespace EtherCatMqttGateway
         private static async Task<int> RunAsync()
         {
             Logger.LogInformation("Starting EtherCatMqttGateway");
-            Logger.LogInformation("Interface={Interface} Broker={Broker}:{Port} ESI={EsiDir} Freq={FreqHz}Hz RetainProcessData={Retain} RootTopic={Topic}",
-                Parsed.Interface, Parsed.Broker, Parsed.Port, Parsed.EsiDir ?? "<default>", Parsed.FrequencyHz, Parsed.RetainProcessData, Parsed.Topic);
+            Logger.LogInformation("Interface={Interface} Broker={Broker}:{Port} ESI={EsiDir} Freq={FreqHz}Hz RetainProcessData={Retain} RootTopic={Topic} ClientId={ClientId} UseReportedCsa={UseReportedCsa}",
+                Parsed.Interface, Parsed.Broker, Parsed.Port, Parsed.EsiDir ?? "<default>", Parsed.FrequencyHz, Parsed.RetainProcessData, Parsed.Topic, Parsed.ClientId, Parsed.UseReportedCsa);
 
             var esiDirectoryPath = Parsed.EsiDir ?? Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ESI");
@@ -226,7 +238,7 @@ namespace EtherCatMqttGateway
             MqttClient = factory.CreateMqttClient();
 
             var mqttOptions = new MqttClientOptionsBuilder()
-                .WithClientId("EtherCATMaster")
+                .WithClientId(Parsed.ClientId)
                 .WithTcpServer(Parsed.Broker, Parsed.Port)
                 .WithCleanSession(false)
                 .WithWillTopic($"{Parsed.Topic}/bridge/status")
@@ -288,7 +300,7 @@ namespace EtherCatMqttGateway
             // Publish static metadata and subscribe to per-slave wildcard output topics.
             foreach (var sd in SlaveDevices)
             {
-                var metaTopic = $"{Parsed.Topic}/{sd.GetCsa()}/metadata";
+                var metaTopic = $"{Parsed.Topic}/{sd.GetCsa(Parsed.UseReportedCsa)}/metadata";
                 var slaveMeta = sd.GetMetadata();
                 var metaPayload = slaveMeta.ToString();
 
@@ -300,7 +312,7 @@ namespace EtherCatMqttGateway
                     .Build();
                 await MqttClient.PublishAsync(msg);
 
-                var outFilter = $"{Parsed.Topic}/{sd.GetCsa()}/+/+";
+                var outFilter = $"{Parsed.Topic}/{sd.GetCsa(Parsed.UseReportedCsa)}/+/+";
                 await MqttClient.SubscribeAsync(
                     new MqttClientSubscribeOptionsBuilder()
                         .WithTopicFilter(outFilter, MqttQualityOfServiceLevel.AtLeastOnce)
@@ -309,7 +321,9 @@ namespace EtherCatMqttGateway
                 slaveSummary[sd.GetCsa().ToString()] = new JObject
                 {
                     ["name"] = slaveMeta["name"],
-                    ["description"] = slaveMeta["description"]
+                    ["description"] = slaveMeta["description"],
+                    ["reportedCsa"] = slaveMeta["reportedCsa"],
+                    ["ringCsa"] = slaveMeta["ringCsa"]
                 };
             }
 
@@ -320,6 +334,7 @@ namespace EtherCatMqttGateway
                 ["frequency_hz"] = Parsed.FrequencyHz,
                 ["esi_path"] = esiDirectoryPath,
                 ["started_utc"] = DateTime.UtcNow,
+                ["topic_csa_mode"] = Parsed.UseReportedCsa ? "reportedCsa" : "ringCsa",
                 ["slaves"] = slaveSummary
             };
             await PublishJsonAsync($"{Parsed.Topic}/bridge/info", info, retain: true);
@@ -347,7 +362,7 @@ namespace EtherCatMqttGateway
                         // Apply queued writes from MQTT.
                         while (PendingWrites.TryDequeue(out var req))
                         {
-                            var sd = SlaveDevices.FirstOrDefault(x => x.GetCsa() == req.Csa);
+                            var sd = SlaveDevices.FirstOrDefault(x => x.GetCsa(Parsed.UseReportedCsa) == req.Csa);
                             if (sd == null) continue;
 
                             var varDesc = sd.GetOutputVariables()
@@ -375,7 +390,7 @@ namespace EtherCatMqttGateway
                             foreach (var v in allVars)
                             {
                                 if (v.DataType <= 0) continue;
-                                var topic = $"{Parsed.Topic}/{sd.GetCsa()}/{v.Index:X4}/{v.SubIndex:X2}";
+                                var topic = $"{Parsed.Topic}/{sd.GetCsa(Parsed.UseReportedCsa)}/{v.Index:X4}/{v.SubIndex:X2}";
                                 var value = sd.ReadVariableAsJToken(v);
                                 snapshot.Add((topic, value));
                             }
@@ -478,7 +493,7 @@ namespace EtherCatMqttGateway
                 return Task.CompletedTask;
             }
 
-            var sd = SlaveDevices.FirstOrDefault(x => x.GetCsa() == csa);
+            var sd = SlaveDevices.FirstOrDefault(x => x.GetCsa(Parsed.UseReportedCsa) == csa);
             if (sd == null) return Task.CompletedTask;
 
             // Validate that this variable is an output before accepting writes.
@@ -552,7 +567,7 @@ namespace EtherCatMqttGateway
 
             foreach (var sd in SlaveDevices)
             {
-                var outFilter = $"{Parsed.Topic}/{sd.GetCsa()}/+/+";
+                var outFilter = $"{Parsed.Topic}/{sd.GetCsa(Parsed.UseReportedCsa)}/+/+";
                 await MqttClient.SubscribeAsync(
                     new MqttClientSubscribeOptionsBuilder()
                         .WithTopicFilter(outFilter, MqttQualityOfServiceLevel.AtLeastOnce)

--- a/EtherCatMqttGateway/Program.cs
+++ b/EtherCatMqttGateway/Program.cs
@@ -55,6 +55,10 @@ namespace EtherCatMqttGateway
         [Option("retain", Required = false, Default = false, HelpText = "Retain process-data messages.")]
         public bool RetainProcessData { get; set; }
 
+        /// <summary>Do not publish the output process data (default: false).</summary>
+        [Option("no-output", Required = false, Default = false, HelpText = "Do not publish the output process data.")]
+        public bool NoOutput { get; set; }
+
         /// <summary>Verbose logging (Information).</summary>
         [Option('v', "verbose", Required = false, Default = false, HelpText = "Verbose logging (Information).")]
         public bool Verbose { get; set; }
@@ -81,6 +85,7 @@ namespace EtherCatMqttGateway
             string? EsiDir,
             uint FrequencyHz,
             bool RetainProcessData,
+            bool NoPublishOutputs,
             LogLevel LogLevel);
 
         private sealed record WriteRequest(ushort Csa, ushort Index, byte SubIndex, JToken Value);
@@ -172,6 +177,7 @@ namespace EtherCatMqttGateway
                 EsiDir: cli.EsiDir,
                 FrequencyHz: cli.FrequencyHz,
                 RetainProcessData: cli.RetainProcessData,
+                NoPublishOutputs: cli.NoOutput,
                 LogLevel: level
             );
         }
@@ -364,13 +370,16 @@ namespace EtherCatMqttGateway
                         Master.UpdateIO(DateTime.UtcNow);
 
                         foreach (var sd in SlaveDevices)
-                            foreach (var v in sd.GetAllVariables())
+                        {
+                            var allVars = Parsed.NoPublishOutputs ? sd.GetInputVariables() : sd.GetAllVariables();
+                            foreach (var v in allVars)
                             {
                                 if (v.DataType <= 0) continue;
                                 var topic = $"{Parsed.Topic}/{sd.GetCsa()}/{v.Index:X4}/{v.SubIndex:X2}";
                                 var value = sd.ReadVariableAsJToken(v);
                                 snapshot.Add((topic, value));
                             }
+                        }
                     }
 
                     // Publish MQTT outside the lock.

--- a/EtherCatMqttGateway/SlaveDevice.cs
+++ b/EtherCatMqttGateway/SlaveDevice.cs
@@ -37,9 +37,11 @@ public class SlaveDevice
     public string GetName() => _slaveInfo.DynamicData.Name;
 
     /// <summary>
-    /// Controller Station Address used for MQTT topics (ring index supplied by the controller).
+    /// CSA (ring index) for this slave; may differ from reported CSA.
     /// </summary>
-    public ushort GetCsa() => _slaveIndex;
+    /// <param name="useReportedCsa">If true, returns the CSA reported by the EtherCAT stack instead of the ring index.</param>
+    /// <returns>CSA as ushort.</returns>
+    public ushort GetCsa(bool useReportedCsa = false) => useReportedCsa ? _slaveInfo.Csa : _slaveIndex;
 
     /// <summary>
     /// CSA reported by the EtherCAT stack (may or may not match ring index).

--- a/README.md
+++ b/README.md
@@ -1,37 +1,36 @@
 # EtherCatMqttGateway
 
-An EtherCAT ⇄ MQTT bridge implemented in C#.  
-It scans an EtherCAT ring, configures slaves, and exposes process data variables over MQTT topics.  
+An EtherCAT ⇄ MQTT bridge implemented in C#.
+It scans an EtherCAT ring, configures slaves, and exposes process data variables over MQTT topics.
 Process data can be monitored and written through MQTT, enabling integration with automation systems and IoT platforms.
 
 ---
 
 ## Features
 
-- EtherCAT master using [EtherCAT.NET](https://github.com/)  
-- Automatic slave scan and PDO mapping from ESI XMLs  
-- Publishes process data to MQTT topics  
-- Subscribes to output variables for remote control  
-- Metadata publishing for each slave  
-- Configurable cycle frequency with overrun detection  
-- Clean shutdown and reconnect handling for MQTT  
-- Configurable via CLI options or Docker environment variables
+* EtherCAT master using [EtherCAT.NET](https://github.com/)
+* Automatic slave scan and PDO mapping from ESI XMLs
+* Publishes process data to MQTT topics
+* Subscribes to output variables for remote control
+* Metadata publishing for each slave
+* Configurable CSA mode for MQTT topics (`ringCsa` vs `reportedCsa`)
+* Configurable cycle frequency with overrun detection
+* Clean shutdown and reconnect handling for MQTT
+* Configurable via CLI options or Docker environment variables
 
 ---
 
 ## Repository Structure
 
 ```
-
 .
 ├── Dockerfile
 ├── entrypoint.sh
 └── EtherCatMqttGateway
-  ├── EtherCatMqttGateway.csproj
-  ├── Program.cs
-  └── SlaveDevice.cs
-
-````
+   ├── EtherCatMqttGateway.csproj
+   ├── Program.cs
+   └── SlaveDevice.cs
+```
 
 ---
 
@@ -41,7 +40,7 @@ Build locally with the .NET SDK:
 
 ```sh
 dotnet publish -c Release EtherCatMqttGateway/EtherCatMqttGateway.csproj -o out
-````
+```
 
 Or build a Docker image:
 
@@ -66,6 +65,10 @@ docker run --rm \
   -e PORT=1883 \
   -e FREQ=20 \
   -e RETAIN=true \
+  -e CLIENT_ID=mygateway \
+  -e TOPIC=plant1/ethercat \
+  -e USE_REPORTED_CSA=true \
+  -e NO_OUTPUT=true \
   -e LOGLEVEL=debug \
   ethercat-mqtt
 ```
@@ -74,8 +77,6 @@ docker run --rm \
 
 ```sh
 docker run --rm \
-  --cap-add NET_RAW \
-  --cap-add NET_ADMIN \
   -v ./esi:/data/esi \
   -e IFACE=eth1 \
   -e BROKER=192.168.1.100 \
@@ -94,15 +95,19 @@ pipework enx207bd22c6b91 <container_id> 0.0.0.0/24
 
 ### Environment variables
 
-| Variable   | Default     | Description                                  |
-| ---------- | ----------- | -------------------------------------------- |
-| `IFACE`    | (required)  | Network interface for EtherCAT (e.g. `eth0`) |
-| `BROKER`   | `127.0.0.1` | MQTT broker hostname or IP                   |
-| `PORT`     | `1883`      | MQTT broker port                             |
-| `ESI_DIR`  | `/data/esi` | Path to ESI XML directory                    |
-| `FREQ`     | `10`        | Cycle frequency in Hz                        |
-| `RETAIN`   | `false`     | Retain MQTT process data messages            |
-| `LOGLEVEL` | `info`      | One of: `debug`, `verbose`, `quiet`, `info`  |
+| Variable           | Default          | Description                                          |
+| ------------------ | ---------------- | ---------------------------------------------------- |
+| `IFACE`            | (required)       | Network interface for EtherCAT (e.g. `eth0`)         |
+| `BROKER`           | `127.0.0.1`      | MQTT broker hostname or IP                           |
+| `PORT`             | `1883`           | MQTT broker port                                     |
+| `ESI_DIR`          | `/data/esi`      | Path to ESI XML directory                            |
+| `FREQ`             | `10`             | Cycle frequency in Hz                                |
+| `RETAIN`           | `false`          | Retain MQTT process data messages                    |
+| `NO_OUTPUT`        | `false`          | Do not publish output variables                      |
+| `CLIENT_ID`        | `EtherCATMaster` | MQTT client ID                                       |
+| `TOPIC`            | `ethercat`       | Root MQTT topic                                      |
+| `USE_REPORTED_CSA` | `false`          | Use reported CSA instead of ring CSA for MQTT topics |
+| `LOGLEVEL`         | `info`           | One of: `debug`, `verbose`, `quiet`, `info`          |
 
 ### CLI options (if not using entrypoint.sh)
 
@@ -115,6 +120,10 @@ dotnet EtherCatMqttGateway.dll \
   --port 1883 \
   --frequency 10 \
   --esi /data/esi \
+  --client-id mygateway \
+  --topic plant1/ethercat \
+  --use-reported-csa \
+  --no-output \
   --retain \
   --debug
 ```
@@ -123,14 +132,14 @@ dotnet EtherCatMqttGateway.dll \
 
 ## MQTT Topics
 
-* `ethercat/<CSA>/metadata` – Metadata for each slave
-* `ethercat/<CSA>/<Index>/<SubIndex>` – Process data variables
-* `ethercat/bridge/status` – Online/offline bridge status
-* `ethercat/bridge/info` – Startup info (interface, ESI path, frequency)
+* `<topic>/<CSA>/metadata` – Metadata for each slave (includes `ringCsa` + `reportedCsa`)
+* `<topic>/<CSA>/<Index>/<SubIndex>` – Process data variables
+* `<topic>/bridge/status` – Online/offline bridge status
+* `<topic>/bridge/info` – Startup info (interface, CSA mode, ESI path, frequency, slaves)
 
 ---
 
 ## Notes
 
 * ESI XML files must be present in the configured ESI directory.
-* The container requires `CAP_NET_RAW` and `CAP_NET_ADMIN` to access EtherCAT interfaces.
+* The container requires `CAP_NET_RAW` and `CAP_NET_ADMIN` to access EtherCAT interfaces **if pipework/macvlan is not used** (e.g. with host networking).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,10 @@ set -e
 : "${FREQ:=10}"
 : "${ESI_DIR:=/data/esi}"
 : "${RETAIN:=false}"
+: "${NO_OUTPUT:=false}"
+: "${CLIENT_ID:=EtherCATMaster}"
+: "${TOPIC:=ethercat}"
+: "${USE_REPORTED_CSA:=false}"
 : "${LOGLEVEL:=info}"
 
 # Ensure ESI directory exists (mounted volume recommended)
@@ -16,8 +20,8 @@ mkdir -p "$ESI_DIR"
 # Map LOGLEVEL env → CLI switches
 LOG_OPTS=""
 case "$LOGLEVEL" in
-  debug) LOG_OPTS="--debug" ;;
-  quiet) LOG_OPTS="--quiet" ;;
+  debug)   LOG_OPTS="--debug" ;;
+  quiet)   LOG_OPTS="--quiet" ;;
   verbose) LOG_OPTS="--verbose" ;;
 esac
 
@@ -25,12 +29,24 @@ esac
 RETAIN_OPT=""
 [ "$RETAIN" = "true" ] && RETAIN_OPT="--retain"
 
+# Map no-output
+NO_OUTPUT_OPT=""
+[ "$NO_OUTPUT" = "true" ] && NO_OUTPUT_OPT="--no-output"
+
+# Map use-reported-csa
+CSA_OPT=""
+[ "$USE_REPORTED_CSA" = "true" ] && CSA_OPT="--use-reported-csa"
+
 exec dotnet EtherCatMqttGateway.dll \
   --iface "$IFACE" \
   --broker "$BROKER" \
   --port "$PORT" \
   --frequency "$FREQ" \
   --esi "$ESI_DIR" \
+  --client-id "$CLIENT_ID" \
+  --topic "$TOPIC" \
   $RETAIN_OPT \
+  $NO_OUTPUT_OPT \
+  $CSA_OPT \
   $LOG_OPTS \
   "$@"


### PR DESCRIPTION
This PR introduces several new features and improvements to the EtherCatMqttGateway:

#### ✨ Features

* **MQTT Client ID**

  * Added `--client-id` CLI option and `CLIENT_ID` environment variable.
  * Allows running multiple gateways against the same broker without conflicts.

* **CSA mode selection**

  * Added `--use-reported-csa` CLI option and `USE_REPORTED_CSA` env var.
  * Enables choosing between `ringCsa` (default) and `reportedCsa` for MQTT topic addressing.
  * `bridge/info` remains keyed by `ringCsa`, but now includes both `ringCsa` and `reportedCsa` in slave metadata.

* **No Output publishing**

  * Added `--no-output` CLI option and `NO_OUTPUT` env var.
  * Suppresses publishing of output PDO variables (inputs only).

#### 🔧 Entrypoint

* Extended `entrypoint.sh` to support new env variables:

  * `CLIENT_ID`, `TOPIC`, `NO_OUTPUT`, `USE_REPORTED_CSA`.

#### 📚 Documentation

* Updated README with:

  * New CLI and environment variables.
  * Clarified MQTT topic structure.
  * Expanded `bridge/info` description.
  * Clarified that `CAP_NET_RAW` and `CAP_NET_ADMIN` are only required if **pipework/macvlan is not used**.

---

This makes the bridge more flexible when integrating with multiple MQTT brokers, ensures CSA topic mapping can follow either ring order or reported ID, and allows users to control whether output PDOs are exposed.